### PR TITLE
kubernetes driver: add support for proxy-url

### DIFF
--- a/driver/kubernetes/context/load.go
+++ b/driver/kubernetes/context/load.go
@@ -19,6 +19,7 @@ import (
 type EndpointMeta struct {
 	context.EndpointMetaBase
 	DefaultNamespace string                           `json:",omitempty"`
+	ProxyURL         string                           `json:",omitempty"`
 	AuthProvider     *clientcmdapi.AuthProviderConfig `json:",omitempty"`
 	Exec             *clientcmdapi.ExecConfig         `json:",omitempty"`
 	UsernamePassword *UsernamePassword                `json:"usernamePassword,omitempty"`
@@ -62,6 +63,9 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 	cfg := clientcmdapi.NewConfig()
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = c.Host
+	if c.ProxyURL != "" {
+		cluster.ProxyURL = c.ProxyURL
+	}
 	cluster.InsecureSkipTLSVerify = c.SkipTLSVerify
 	authInfo := clientcmdapi.NewAuthInfo()
 	if c.TLSData != nil {

--- a/driver/kubernetes/context/save.go
+++ b/driver/kubernetes/context/save.go
@@ -21,6 +21,17 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 	if err != nil {
 		return Endpoint{}, err
 	}
+
+	var proxyURLString string
+	if clientcfg.Proxy != nil {
+		proxyURL, err := clientcfg.Proxy(nil)
+		if err != nil {
+			return Endpoint{}, err
+		}
+
+		proxyURLString = proxyURL.String()
+	}
+
 	var ca, key, cert []byte
 	if ca, err = readFileOrDefault(clientcfg.CAFile, clientcfg.CAData); err != nil {
 		return Endpoint{}, err
@@ -53,6 +64,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 				SkipTLSVerify: clientcfg.Insecure,
 			},
 			DefaultNamespace: ns,
+			ProxyURL:         proxyURLString,
 			AuthProvider:     clientcfg.AuthProvider,
 			Exec:             clientcfg.ExecProvider,
 			UsernamePassword: usernamePassword,


### PR DESCRIPTION
Adds support for proxy-url in kubeconfig.

Kubeconfig with proxy-url, is not supported by the buildx kubernetes driver.
https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#proxy

This PR attempts to add this support - and will initialize the client used for k8s access with the right proxy-url parameter.